### PR TITLE
Sanitize bounty rich text rendering

### DIFF
--- a/src/app/(pages)/bounty/[id]/page.tsx
+++ b/src/app/(pages)/bounty/[id]/page.tsx
@@ -33,6 +33,7 @@ import {
 } from "@/components/ui/dialog";
 import { toast } from "react-toastify";
 import Login from "@/components/Login/Login";
+import SafeHtml from "@/components/SafeHtml";
 
 const bountySubmission = {
   links: [],
@@ -460,12 +461,10 @@ const BountyDetails = () => {
                     <p className=" underline underline-offset-4 font-semibold">
                       Description
                     </p>
-                    <div
+                    <SafeHtml
                       className="w-full "
-                      dangerouslySetInnerHTML={{
-                        __html: bounty?.bountyDescription ?? "",
-                      }}
-                    ></div>
+                      html={bounty?.bountyDescription}
+                    />
                   </div>
 
                   <div className="w-full flex flex-col gap-4">

--- a/src/app/(pages)/profile/[username]/submission/[bountyid]/page.tsx
+++ b/src/app/(pages)/profile/[username]/submission/[bountyid]/page.tsx
@@ -14,6 +14,7 @@ import { useSelector } from "react-redux";
 import { cn } from "@/lib/utils";
 import { toast } from "react-toastify";
 import { adminGithub } from "@/lib/constants";
+import SafeHtml from "@/components/SafeHtml";
 
 interface submission {
   bountyId: string;
@@ -327,13 +328,10 @@ const UserSubmisson = () => {
                   </div>
                 </div>
                 <div className="w-full flex flex-col gap-4">
-                  <div
+                  <SafeHtml
                     className="w-full italic "
-                    dangerouslySetInnerHTML={{
-                      __html:
-                        submissionDetails?.bounty?.bountyDescription ?? "",
-                    }}
-                  ></div>
+                    html={submissionDetails?.bounty?.bountyDescription}
+                  />
                 </div>
 
                 <div className="w-full flex flex-col gap-4">

--- a/src/components/SafeHtml/index.tsx
+++ b/src/components/SafeHtml/index.tsx
@@ -1,0 +1,105 @@
+"use client";
+
+import { useMemo } from "react";
+
+const ALLOWED_TAGS = new Set([
+  "a",
+  "blockquote",
+  "br",
+  "code",
+  "em",
+  "h1",
+  "h2",
+  "h3",
+  "i",
+  "img",
+  "li",
+  "mark",
+  "ol",
+  "p",
+  "pre",
+  "s",
+  "span",
+  "strong",
+  "u",
+  "ul",
+]);
+
+const ALLOWED_ATTRIBUTES: Record<string, Set<string>> = {
+  a: new Set(["href", "rel", "target", "title"]),
+  img: new Set(["alt", "src", "title"]),
+};
+
+const URL_ATTRIBUTES = new Set(["href", "src"]);
+
+function isSafeUrl(value: string, attribute: string) {
+  try {
+    const parsed = new URL(value, window.location.origin);
+    if (attribute === "src") {
+      return ["http:", "https:"].includes(parsed.protocol);
+    }
+    return ["http:", "https:", "mailto:", "tel:"].includes(parsed.protocol);
+  } catch {
+    return false;
+  }
+}
+
+function sanitizeElement(element: Element) {
+  for (const child of Array.from(element.children)) {
+    sanitizeElement(child);
+  }
+
+  const tagName = element.tagName.toLowerCase();
+  if (!ALLOWED_TAGS.has(tagName)) {
+    element.replaceWith(...Array.from(element.childNodes));
+    return;
+  }
+
+  const allowedAttributes = ALLOWED_ATTRIBUTES[tagName] ?? new Set<string>();
+  for (const attribute of Array.from(element.attributes)) {
+    const attributeName = attribute.name.toLowerCase();
+    const shouldKeep =
+      allowedAttributes.has(attributeName) &&
+      (!URL_ATTRIBUTES.has(attributeName) ||
+        isSafeUrl(attribute.value, attributeName));
+
+    if (!shouldKeep) {
+      element.removeAttribute(attribute.name);
+    }
+  }
+
+  if (tagName === "a" && element.getAttribute("href")) {
+    element.setAttribute("rel", "noopener noreferrer");
+    element.setAttribute("target", "_blank");
+  }
+}
+
+function sanitizeHtml(html: string) {
+  if (typeof window === "undefined") {
+    return "";
+  }
+
+  const document = new DOMParser().parseFromString(html, "text/html");
+  for (const child of Array.from(document.body.children)) {
+    sanitizeElement(child);
+  }
+
+  return document.body.innerHTML;
+}
+
+export default function SafeHtml({
+  className,
+  html,
+}: {
+  className?: string;
+  html?: string | null;
+}) {
+  const sanitizedHtml = useMemo(() => sanitizeHtml(html ?? ""), [html]);
+
+  return (
+    <div
+      className={className}
+      dangerouslySetInnerHTML={{ __html: sanitizedHtml }}
+    />
+  );
+}


### PR DESCRIPTION
## Summary
- add a reusable `SafeHtml` component that sanitizes rich-text HTML before rendering it
- replace raw bounty description `dangerouslySetInnerHTML` usage on public bounty and submission detail pages
- strip unsafe tags, event-handler attributes, and unsafe URL protocols while preserving common rich-text formatting

## Security impact
Bounty descriptions are stored as HTML from the rich text editor and later rendered into pages. Rendering that stored HTML directly can allow unsafe markup to execute if malicious HTML reaches the field. This change keeps the rich text display path but removes scripts, inline handlers, and `javascript:`/unsafe image URLs before insertion.

## Testing
- `npm install --no-package-lock --legacy-peer-deps`
- `npm run lint`
- `npx tsc --noEmit`
- `git diff --check`

Note: `npm install --no-package-lock` without `--legacy-peer-deps` fails on the existing `next-auth`/`nodemailer` peer dependency conflict, so the legacy peer dependency mode was used for local verification.